### PR TITLE
feat: Add provider timeout configuration

### DIFF
--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -183,6 +183,12 @@ func WithClient(client HTTPClient) SDKOption {
 	}
 }
 
+func WithTimeout(timeout time.Duration) SDKOption {
+	return func(sdk *SDK) {
+		sdk.sdkConfiguration.DefaultClient = &http.Client{Timeout: timeout}
+	}
+}
+
 func withSecurity(security interface{}) func(context.Context) (interface{}, error) {
 	return func(context.Context) (interface{}, error) {
 		return &security, nil


### PR DESCRIPTION
##  Proof of Concept: Timeout Configuration for Provider

This is a **proof of concept** for adding a `timeout` configuration to the Airbyte provider.
I did **not** dig deep into the internals of the codebase.

Tested **locally only**.

---

###  Example Configuration

```hcl
provider "airbyte" {
  server_url = local.server_url
  username   = var.AIRBYTE_API_USER
  password   = var.AIRBYTE_API_PASSWORD
  timeout    = 300
}
```

---

### Sample Output During Long Operation

```
module.common.airbyte_source_definition.clickhouse_custom: Still creating... [4m50s elapsed]
module.common.airbyte_source_definition.clickhouse_custom: Still creating... [5m0s elapsed]
```

---

Let me know if you'd like me to iterate further or test with additional scenarios.
